### PR TITLE
enable 'all' special-rule & include scrape_url in message for slack

### DIFF
--- a/outputs/slack_output.py
+++ b/outputs/slack_output.py
@@ -24,7 +24,7 @@ class SlackOutput():
 
     def store_paste(self, paste_data):
         if self.valid:
-            send = False
+            send = ('all' in self.accepted_rules)
 
             for rule in self.accepted_rules:
                 if rule in paste_data['YaraRule']:
@@ -38,7 +38,7 @@ class SlackOutput():
                             "fallback": "Plan a vacation",
                             "author_name": "PasteHunter",
                             "title": "Paste ID {0}".format(paste_data['pasteid']),
-                            "text": "Yara Rule {0} Found on {1}".format(paste_data['YaraRule'], paste_data['pastesite'])
+                            "text": "Yara Rule {0} Found on {1}\n\r{2}".format(paste_data['YaraRule'], paste_data['pastesite'], paste_data['scrape_url'])
                         }
                     ]
                 }


### PR DESCRIPTION
I noticed that SMTP output had a convenient `all` special rule and for my use-case, that'd be really helpful for slack output as well. I also added the `scrape_url` to the slack message so that one can easily get the contents of the scrape without dumping the raw paste into slack.