### PR TITLE
Added support for compressing paste contents

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -27,6 +27,7 @@ This output module will store each paste in a json file on disk. The name of the
 
 - **output_path**: Path on disk to store output files. 
 - **store_raw**: Include the raw paste in the json file. False jsut stores metadata.
+- **compress_raw**: Compresses the data using LZMA if it will reduce the size. Can be decompressed by base64-decoding, then using the `xz command <https://www.systutorials.com/docs/linux/man/1-xz/>`_.
 - **encode_raw**: Ignored, Reserved for future usage.
 
 CSV

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -27,7 +27,6 @@ This output module will store each paste in a json file on disk. The name of the
 
 - **output_path**: Path on disk to store output files. 
 - **store_raw**: Include the raw paste in the json file. False jsut stores metadata.
-- **compress_raw**: Compresses the data using LZMA if it will reduce the size. Can be decompressed by base64-decoding, then using the `xz command <https://www.systutorials.com/docs/linux/man/1-xz/>`_.
 - **encode_raw**: Ignored, Reserved for future usage.
 
 CSV

--- a/docs/postprocess.rst
+++ b/docs/postprocess.rst
@@ -51,3 +51,10 @@ Entropy
 This postprocess module calculates shannon entropy on the raw paste data. This can be used to help identify binary and encoded or encrytped data. 
 
 - **rule_list**: List of rules that will trigger the postprocess module. 
+
+Compress
+-------
+Compresses the data using LZMA(lossless compression) if it will reduce the size. Small pastes or pastes that don't benefit from compression will not be affected by this module. 
+Its outputs can be decompressed by base64-decoding, then using the `xz command <https://www.systutorials.com/docs/linux/man/1-xz/>`_.
+
+- **rule_list**: List of rules that will trigger the postprocess module. 

--- a/outputs/json_output.py
+++ b/outputs/json_output.py
@@ -1,3 +1,5 @@
+import base64
+import lzma
 import os
 import datetime
 import json
@@ -25,6 +27,22 @@ class JsonOutput():
     def store_paste(self, paste_data):
         if not config['outputs']['json_output']['store_raw']:
             del paste_data['raw_paste']
+        elif config['outputs']['json_output']['compress_raw']:
+            original = paste_data['raw_paste']
+            orig_size = len(original.encode())
+            logger.debug("Compressing paste... Pre-compression size: {}", orig_size)
+            compressed = base64.b64encode(lzma.compress(paste_data['raw_paste'].encode()))
+            compressed_size = len(compressed)
+            logger.debug("Compressing paste... Post-compression size: {}", compressed_size)
+
+            # In some cases compressed blobs may be larger
+            # if not much data is compressed
+            if orig_size > compressed_size:
+                paste_data['raw_paste'] = compressed.decode('utf-8')
+                logger.debug("Compressed data smaller than original blob. Keeping compressed.")
+            else:
+                logger.debug("Original smaller than compressed blob. Keeping original.")
+
 
         if self.test:
             json_file = os.path.join(self.json_path, str(paste_data['pasteid']))

--- a/outputs/json_output.py
+++ b/outputs/json_output.py
@@ -27,22 +27,6 @@ class JsonOutput():
     def store_paste(self, paste_data):
         if not config['outputs']['json_output']['store_raw']:
             del paste_data['raw_paste']
-        elif config['outputs']['json_output']['compress_raw']:
-            original = paste_data['raw_paste']
-            orig_size = len(original.encode())
-            logger.debug("Compressing paste... Pre-compression size: {}", orig_size)
-            compressed = base64.b64encode(lzma.compress(paste_data['raw_paste'].encode()))
-            compressed_size = len(compressed)
-            logger.debug("Compressing paste... Post-compression size: {}", compressed_size)
-
-            # In some cases compressed blobs may be larger
-            # if not much data is compressed
-            if orig_size > compressed_size:
-                paste_data['raw_paste'] = compressed.decode('utf-8')
-                logger.debug("Compressed data smaller than original blob. Keeping compressed.")
-            else:
-                logger.debug("Original smaller than compressed blob. Keeping original.")
-
 
         if self.test:
             json_file = os.path.join(self.json_path, str(paste_data['pasteid']))

--- a/pastehunter.py
+++ b/pastehunter.py
@@ -270,10 +270,15 @@ def paste_scanner():
                     sha256 = hashlib.sha256(encoded_paste_data).hexdigest()
                     paste_data['MD5'] = md5
                     paste_data['SHA256'] = sha256
-                    paste_data['raw_paste'] = raw_paste_data
+                    # It is possible a post module modified or set this field.
+                    if not paste_data.get('raw_paste'):
+                        paste_data['raw_paste'] = raw_paste_data
+                        paste_data['size'] = len(raw_paste_data)
+                    else:
+                        # Set size based on modified value
+                        paste_data['size'] = len(paste_data['raw_paste'])
+                    
                     paste_data['YaraRule'] = results
-                    # Set the size for all pastes - This will override any size set by the source
-                    paste_data['size'] = len(raw_paste_data)
                     for output in outputs:
                         try:
                             output.store_paste(paste_data)

--- a/postprocess/post_compress.py
+++ b/postprocess/post_compress.py
@@ -1,0 +1,26 @@
+import lzma
+import base64
+import logging
+from common import parse_config
+logger = logging.getLogger('pastehunter')
+config = parse_config()
+
+def run(results, raw_paste_data, paste_object):
+    if config['outputs']['json_output']['store_raw']:
+        original = raw_paste_data
+        orig_size = len(original.encode())
+        logger.debug("Compressing paste... Pre-compression size: {}", orig_size)
+        compressed = base64.b64encode(lzma.compress(raw_paste_data.encode()))
+        compressed_size = len(compressed)
+        logger.debug("Compressing paste... Post-compression size: {}", compressed_size)
+
+        # In some cases compressed blobs may be larger
+        # if not much data is compressed
+        if orig_size > compressed_size:
+            paste_object['raw_paste'] = compressed.decode('utf-8')
+            logger.debug("Compressed data smaller than original blob. Keeping compressed.")
+        else:
+            logger.debug("Original smaller than compressed blob. Keeping original.")
+
+    # Regardless of modification, return the paste object
+    return paste_object

--- a/settings.json.sample
+++ b/settings.json.sample
@@ -64,7 +64,6 @@
       "classname": "JsonOutput",
       "output_path": "logs/json/",
       "store_raw": true,
-      "compress_raw": true,
       "encode_raw": true
     },
     "csv_output": {
@@ -159,6 +158,11 @@
     "post_entropy": {
       "enabled": false,
       "module": "postprocess.post_entropy",
+      "rule_list": ["ALL"]
+    },
+    "post_compress": {
+      "enabled": true,
+      "module": "postprocess.post_compress",
       "rule_list": ["ALL"]
     }
   }

--- a/settings.json.sample
+++ b/settings.json.sample
@@ -64,6 +64,7 @@
       "classname": "JsonOutput",
       "output_path": "logs/json/",
       "store_raw": true,
+      "compress_raw": true,
       "encode_raw": true
     },
     "csv_output": {


### PR DESCRIPTION
This change adds support for compressing pastes (if it would reduce size). Shorter pastes, such as single urls won't be compressed, as this may actually increase the size of the data. I am using LZMA to compress the data, then base64-encoding that.