### PR TITLE
Fix filename yara rules

### DIFF
--- a/inputs/pastebin.py
+++ b/inputs/pastebin.py
@@ -31,6 +31,7 @@ def recent_pastes(conf, input_history):
 
             # Create a new paste dict for us to normalize
             paste_data = paste
+            paste_data['filename'] = paste['key']
             paste_data['confname'] = 'pastebin'
             paste_data['pasteid'] = paste['key']
             paste_data['pastesite'] = 'pastebin.com'

--- a/inputs/stackexchange.py
+++ b/inputs/stackexchange.py
@@ -58,6 +58,7 @@ def recent_pastes(conf, input_history):
     
                 # Create a new question dict for us to normalize
                 question_data = question
+                question_data['filename'] = ''
                 question_data['confname'] = "stackexchange"
                 # Force type to string else it breaks ES Index mappings
                 question_data['pasteid'] = str(question['question_id']) 

--- a/settings.json.sample
+++ b/settings.json.sample
@@ -182,7 +182,7 @@
       "rule_list": ["ALL"]
     },
     "post_compress": {
-      "enabled": true,
+      "enabled": false,
       "module": "postprocess.post_compress",
       "rule_list": ["ALL"]
     }


### PR DESCRIPTION
Adds filename to Pastebin and StackExchange inputs to prevent yara compile errors. 

Fixes https://github.com/kevthehermit/PasteHunter/issues/89