### PR TITLE
minor import path fix

### DIFF
--- a/pastehunter/inputs/ixio.py
+++ b/pastehunter/inputs/ixio.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import List, Any, Dict, Union, Pattern
 
 from common import base62_decode, base62_encode
-from inputs.base_input import BasePasteSite
+from pastehunter.inputs.base_input import BasePasteSite
 
 logger = logging.getLogger('pastehunter')
 

--- a/pastehunter/inputs/pastebin.py
+++ b/pastehunter/inputs/pastebin.py
@@ -4,7 +4,7 @@ import requests
 import logging
 from datetime import datetime
 
-from inputs.base_input import BasePasteSite
+from pastehunter.inputs.base_input import BasePasteSite
 
 logger = logging.getLogger('pastehunter')
 

--- a/pastehunter/inputs/slexy.py
+++ b/pastehunter/inputs/slexy.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from time import sleep
 from typing import Any, Dict, Optional, List, Union
 
-from inputs.base_input import BasePasteSite
+from pastehunter.inputs.base_input import BasePasteSite
 
 logger = logging.getLogger('pastehunter')
 


### PR DESCRIPTION
hello, thanks for all your work this repo.

I couldn't get these modules to work with the updated base_inputs.py class definition without specifying the full path in the import statement. 

super minor pull obviously, feel free to test before merging if my config was somehow bad. 