### PR TITLE
Fix http output module on sample

### DIFF
--- a/settings.json.sample
+++ b/settings.json.sample
@@ -137,7 +137,7 @@
     },
     "http_output": {
       "enabled": false,
-      "module": "outputs.http_output",
+      "module": "pastehunter.outputs.http_output",
       "classname": "HttpOutput",
       "endpoint_url": "",
       "headers": {},


### PR DESCRIPTION
When I was testing http output and I was receiving some errors, but I just figured it out it's missing the 'pastehunter' module on the sample.